### PR TITLE
Update gradle settings.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,5 +25,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:design:23.0.1'
     compile 'com.facebook.android:facebook-android-sdk:4.0.0'
-    compile 'com.google.android.gms:play-services:7.5.0'
+    compile 'com.google.android.gms:play-services:8.3.0'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
+		classpath 'com.google.gms:google-services:1.5.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
When I tried to build this boilerplate directly after cloning, I found error regarding the Google Play Service dependencies. So, I updated the build.gradle script in both level (project and app) then I solved the compiling problem. May this useful.
- _./build.gradle_: add `classpath 'com.google.gms:google-services:1.5.0-beta2'` into `dependencies`.
- _./app/build.gradle_: update Google Play Services version to `compile 'com.google.android.gms:play-services:8.3.0'`; add `apply plugin: 'com.google.gms.google-services'` at the end of file.
